### PR TITLE
typo: whitespace cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 TamaGo - bare metal Go for ARM SoCs
 ===================================
 
-tamago | https://github.com/f-secure-foundry/tamago  
+tamago | https://github.com/f-secure-foundry/tamago
 
-Copyright (c) F-Secure Corporation  
+Copyright (c) F-Secure Corporation
 https://foundry.f-secure.com
 
 ![TamaGo gopher](https://github.com/f-secure-foundry/tamago/wiki/images/tamago.svg?sanitize=true)
@@ -11,11 +11,11 @@ https://foundry.f-secure.com
 Authors
 =======
 
-Andrea Barisani  
-andrea.barisani@f-secure.com | andrea@inversepath.com  
+Andrea Barisani
+andrea.barisani@f-secure.com | andrea@inversepath.com
 
-Andrej Rosano  
-andrej.rosano@f-secure.com   | andrej@inversepath.com  
+Andrej Rosano
+andrej.rosano@f-secure.com   | andrej@inversepath.com
 
 Introduction
 ============
@@ -76,8 +76,8 @@ The following table summarizes currently supported SoCs and boards.
 |---------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------|
 | NXP i.MX6ULL  | [USB armory Mk II](https://github.com/f-secure-foundry/usbarmory/wiki)                                                                                                               | [imx6](https://github.com/f-secure-foundry/tamago/tree/master/soc/imx6)       | [usbarmory/mark-two](https://github.com/f-secure-foundry/tamago/tree/master/board/f-secure/usbarmory)  |
 | NXP i.MX6ULL  | [MCIMX6ULL-EVK](https://www.nxp.com/design/development-boards/i-mx-evaluation-and-development-boards/evaluation-kit-for-the-i-mx-6ull-and-6ulz-applications-processor:MCIMX6ULL-EVK) | [imx6](https://github.com/f-secure-foundry/tamago/tree/master/soc/imx6)       | [mx6ullevk](https://github.com/f-secure-foundry/tamago/tree/master/board/nxp/mx6ullevk)                |
-| BCM2835       | [Raspberry Pi Zero](https://www.raspberrypi.org/products/raspberry-pi-zero)                                                                                                          | [bcm2835](https://github.com/f-secure-foundry/tamago/tree/master/soc/bcm2835) | [pi/pizero](https://github.com/f-secure-foundry/tamago/tree/master/board/raspberrypi)                       |
-| BCM2836       | [Raspberry Pi 2](https://www.raspberrypi.org/products/raspberry-pi-2-model-b)                                                                                                        | [bcm2835](https://github.com/f-secure-foundry/tamago/tree/master/soc/bcm2835) | [pi/pi2](https://github.com/f-secure-foundry/tamago/tree/master/board/raspberrypi)                          |
+| BCM2835       | [Raspberry Pi Zero](https://www.raspberrypi.org/products/raspberry-pi-zero)                                                                                                          | [bcm2835](https://github.com/f-secure-foundry/tamago/tree/master/soc/bcm2835) | [pi/pizero](https://github.com/f-secure-foundry/tamago/tree/master/board/raspberrypi)                  |
+| BCM2836       | [Raspberry Pi 2](https://www.raspberrypi.org/products/raspberry-pi-2-model-b)                                                                                                        | [bcm2835](https://github.com/f-secure-foundry/tamago/tree/master/soc/bcm2835) | [pi/pi2](https://github.com/f-secure-foundry/tamago/tree/master/board/raspberrypi)                     |
 
 Compiling
 =========
@@ -126,7 +126,7 @@ execution.
 License
 =======
 
-tamago | https://github.com/f-secure-foundry/tamago  
+tamago | https://github.com/f-secure-foundry/tamago
 Copyright (c) F-Secure Corporation
 
 This program is free software: you can redistribute it and/or modify it under

--- a/_dev/gen_import_report.go
+++ b/_dev/gen_import_report.go
@@ -62,7 +62,7 @@ const readmeTemplate = `
 This project imports each package in the stdlib and reports if it imports cleanly in tamago.
 A package with a check may work a package with a x will definately not currently work.
 
-| Package | Imported? | 
+| Package | Imported? |
 | --- | --- |{{ range $key, $value := .}}
 | {{$value.Name}} | {{if $value.Imported}} ok {{else}} [failed](#{{$value.Link}}) {{end}} | {{ end }}
 

--- a/board/f-secure/usbarmory/README.md
+++ b/board/f-secure/usbarmory/README.md
@@ -1,9 +1,9 @@
 TamaGo - bare metal Go for ARM SoCs - USB armory support
 ========================================================
 
-tamago | https://github.com/f-secure-foundry/tamago  
+tamago | https://github.com/f-secure-foundry/tamago
 
-Copyright (c) F-Secure Corporation  
+Copyright (c) F-Secure Corporation
 https://foundry.f-secure.com
 
 ![TamaGo gopher](https://github.com/f-secure-foundry/tamago/wiki/images/tamago.svg?sanitize=true)
@@ -11,11 +11,11 @@ https://foundry.f-secure.com
 Authors
 =======
 
-Andrea Barisani  
-andrea.barisani@f-secure.com | andrea@inversepath.com  
+Andrea Barisani
+andrea.barisani@f-secure.com | andrea@inversepath.com
 
-Andrej Rosano  
-andrej.rosano@f-secure.com   | andrej@inversepath.com  
+Andrej Rosano
+andrej.rosano@f-secure.com   | andrej@inversepath.com
 
 Introduction
 ============
@@ -173,7 +173,7 @@ continue
 License
 =======
 
-tamago | https://github.com/f-secure-foundry/tamago  
+tamago | https://github.com/f-secure-foundry/tamago
 Copyright (c) F-Secure Corporation
 
 This program is free software: you can redistribute it and/or modify it under

--- a/board/nxp/mx6ullevk/README.md
+++ b/board/nxp/mx6ullevk/README.md
@@ -1,9 +1,9 @@
 TamaGo - bare metal Go for ARM SoCs - MCIMX6ULL-EVK support
 ===========================================================
 
-tamago | https://github.com/f-secure-foundry/tamago  
+tamago | https://github.com/f-secure-foundry/tamago
 
-Copyright (c) F-Secure Corporation  
+Copyright (c) F-Secure Corporation
 https://foundry.f-secure.com
 
 ![TamaGo gopher](https://github.com/f-secure-foundry/tamago/wiki/images/tamago.svg?sanitize=true)
@@ -11,11 +11,11 @@ https://foundry.f-secure.com
 Authors
 =======
 
-Andrea Barisani  
-andrea.barisani@f-secure.com | andrea@inversepath.com  
+Andrea Barisani
+andrea.barisani@f-secure.com | andrea@inversepath.com
 
-Andrej Rosano  
-andrej.rosano@f-secure.com   | andrej@inversepath.com  
+Andrej Rosano
+andrej.rosano@f-secure.com   | andrej@inversepath.com
 
 Introduction
 ============
@@ -187,7 +187,7 @@ continue
 License
 =======
 
-tamago | https://github.com/f-secure-foundry/tamago  
+tamago | https://github.com/f-secure-foundry/tamago
 Copyright (c) F-Secure Corporation
 
 This program is free software: you can redistribute it and/or modify it under

--- a/board/raspberrypi/README.md
+++ b/board/raspberrypi/README.md
@@ -1,9 +1,9 @@
 TamaGo - bare metal Go for ARM SoCs - Raspberry Pi Support
 ==========================================================
 
-tamago | https://github.com/f-secure-foundry/tamago  
+tamago | https://github.com/f-secure-foundry/tamago
 
-Copyright (c) the pi/pi2/pizero package authors  
+Copyright (c) the pi/pi2/pizero package authors
 
 ![TamaGo gopher](https://github.com/f-secure-foundry/tamago/wiki/images/tamago.svg?sanitize=true)
 
@@ -162,10 +162,10 @@ of mapping 'LF' to 'CRLF' as-needed.
 License
 =======
 
-tamago | https://github.com/f-secure-foundry/tamago  
+tamago | https://github.com/f-secure-foundry/tamago
 Copyright (c) F-Secure Corporation
 
-raspberrypi | https://github.com/f-secure-foundry/tamago/tree/master/board/raspberrypi  
+raspberrypi | https://github.com/f-secure-foundry/tamago/tree/master/board/raspberrypi
 Copyright (c) the pi package authors
 
 This program is free software: you can redistribute it and/or modify it under

--- a/soc/bcm2835/README.md
+++ b/soc/bcm2835/README.md
@@ -3,7 +3,7 @@ TamaGo - bare metal Go for ARM SoCs - BCM2835 support
 
 tamago | https://github.com/f-secure-foundry/tamago
 
-Copyright (c) the bcm2835 package authors  
+Copyright (c) the bcm2835 package authors
 
 Contributors
 ============
@@ -42,10 +42,10 @@ for documentation on compiling and executing on these boards.
 License
 =======
 
-tamago | https://github.com/f-secure-foundry/tamago  
+tamago | https://github.com/f-secure-foundry/tamago
 Copyright (c) F-Secure Corporation
 
-bcm2835 | https://github.com/f-secure-foundry/tamago/tree/master/soc/bcm2835  
+bcm2835 | https://github.com/f-secure-foundry/tamago/tree/master/soc/bcm2835
 Copyright (c) the bcm2835 package authors
 
 This program is free software: you can redistribute it and/or modify it under

--- a/soc/imx6/README.md
+++ b/soc/imx6/README.md
@@ -1,9 +1,9 @@
 TamaGo - bare metal Go for ARM SoCs - i.MX 6 support
 ====================================================
 
-tamago | https://github.com/f-secure-foundry/tamago  
+tamago | https://github.com/f-secure-foundry/tamago
 
-Copyright (c) F-Secure Corporation  
+Copyright (c) F-Secure Corporation
 https://foundry.f-secure.com
 
 ![TamaGo gopher](https://github.com/f-secure-foundry/tamago/wiki/images/tamago.svg?sanitize=true)
@@ -11,11 +11,11 @@ https://foundry.f-secure.com
 Authors
 =======
 
-Andrea Barisani  
-andrea.barisani@f-secure.com | andrea@inversepath.com  
+Andrea Barisani
+andrea.barisani@f-secure.com | andrea@inversepath.com
 
-Andrej Rosano  
-andrej.rosano@f-secure.com   | andrej@inversepath.com  
+Andrej Rosano
+andrej.rosano@f-secure.com   | andrej@inversepath.com
 
 Introduction
 ============
@@ -46,7 +46,7 @@ Supported hardware
 License
 =======
 
-tamago | https://github.com/f-secure-foundry/tamago  
+tamago | https://github.com/f-secure-foundry/tamago
 Copyright (c) F-Secure Corporation
 
 This program is free software: you can redistribute it and/or modify it under


### PR DESCRIPTION
This PR removes the unnecessary whitespace.

It can be seen here that only the whitespace changes are introduced: https://github.com/f-secure-foundry/tamago/pull/7/files?&w=1