### PR TITLE
More flexible USB setup flow

### DIFF
--- a/soc/imx6/usb/descriptor.go
+++ b/soc/imx6/usb/descriptor.go
@@ -343,11 +343,7 @@ func (d *DeviceQualifierDescriptor) Bytes() []byte {
 
 // SetupFunction represents the function to process class-specific setup
 // requests.
-type SetupFunction func(setup *SetupData) (in []byte, err error)
-
-// SetupConditionalFunc represents the function used to detect whether a class-specific setup request
-// should be handled by a custom request handler or not.
-type SetupConditionalFunc func(setup *SetupData) bool
+type SetupFunction func(setup *SetupData) (in []byte, done, ack bool, err error)
 
 // Device is a collection of USB device descriptors and host driven settings
 // to represent a USB device.
@@ -363,8 +359,6 @@ type Device struct {
 
 	// Optional class-specific setup handler
 	Setup SetupFunction
-	DescriptorSetup SetupFunction
-	Conditional SetupConditionalFunc
 }
 
 func (d *Device) setStringDescriptor(s []byte, zero bool) (uint8, error) {

--- a/soc/imx6/usb/descriptor.go
+++ b/soc/imx6/usb/descriptor.go
@@ -343,7 +343,7 @@ func (d *DeviceQualifierDescriptor) Bytes() []byte {
 
 // SetupFunction represents the function to process class-specific setup
 // requests.
-type SetupFunction func(setup *SetupData) (in []byte, done, ack bool, err error)
+type SetupFunction func(setup *SetupData) (in []byte, done bool, ack bool, err error)
 
 // Device is a collection of USB device descriptors and host driven settings
 // to represent a USB device.

--- a/soc/imx6/usb/descriptor.go
+++ b/soc/imx6/usb/descriptor.go
@@ -345,6 +345,10 @@ func (d *DeviceQualifierDescriptor) Bytes() []byte {
 // requests.
 type SetupFunction func(setup *SetupData) (in []byte, err error)
 
+// SetupConditionalFunc represents the function used to detect whether a class-specific setup request
+// should be handled by a custom request handler or not.
+type SetupConditionalFunc func(setup *SetupData) bool
+
 // Device is a collection of USB device descriptors and host driven settings
 // to represent a USB device.
 type Device struct {
@@ -359,6 +363,8 @@ type Device struct {
 
 	// Optional class-specific setup handler
 	Setup SetupFunction
+	DescriptorSetup SetupFunction
+	Conditional SetupConditionalFunc
 }
 
 func (d *Device) setStringDescriptor(s []byte, zero bool) (uint8, error) {

--- a/soc/imx6/usb/setup.go
+++ b/soc/imx6/usb/setup.go
@@ -149,13 +149,11 @@ func (hw *USB) doSetup(dev *Device, setup *SetupData) (err error) {
 	}
 
 	if dev.Setup != nil {
-		var in []byte
-		var done, ack bool
-		
-		in, done, ack, err = dev.Setup(setup)
+		in, done, ack, err := dev.Setup(setup)
 
 		if err != nil {
 			hw.stall(0, IN)
+			return err
 		} else if len(in) != 0 {
 			err = hw.tx(0, false, in)
 		} else if ack {
@@ -163,7 +161,7 @@ func (hw *USB) doSetup(dev *Device, setup *SetupData) (err error) {
 		}
 
 		if done {
-			return
+			return err
 		}
 
 	}


### PR DESCRIPTION
This PR adds a way for users to handle custom USB descriptor
requests by adding a new Device struct field called `DescriptorSetup`,
just like the `Setup` field.

A new field called `Conditional` has been added to the Device type.

This field let the user decide whether a SetupData request should be handled
by `usb.doSetup()` or by other logic defined in `Conditiona` function logic.

Both functions are optional, and their presence doesn't impact the logic
currently implemented in Tamago's USB stack.